### PR TITLE
Cranelift: tweak additional flags to ignore

### DIFF
--- a/asm_v_wasm/wasm_bench.py
+++ b/asm_v_wasm/wasm_bench.py
@@ -175,7 +175,7 @@ def run_test(isVerbose, noThreads, shell, program, mode, argument):
     if mode == "ion":
         cmd.append("--wasm-compiler=ion")
     if mode == "cranelift":
-        cmd.append("--no-wasm-multi-value")
+        cmd.append("--no-wasm-simd")
         cmd.append("--shared-memory=off")
         cmd.append("--wasm-compiler=cranelift")
     if noThreads:


### PR DESCRIPTION
Multi-value is now supported in Cranelift; simd is not, on x64.